### PR TITLE
DB username needs to match with docker-compose-dev

### DIFF
--- a/content/docs/backend-install.md
+++ b/content/docs/backend-install.md
@@ -29,8 +29,8 @@ Step-by-step guide to setup Avia Commerce locally for development and contributi
 ```
   config :snitch_core, Snitch.Repo,
     adapter: Ecto.Adapters.Postgres,
-    username: "postgres",
-    password: "postgres",
+    username: "snitch_dev",
+    password: "snitch_dev",
     database: "snitch_dev",
     hostname: "db",
     pool_size: 10


### PR DESCRIPTION
avia/config/docker/dev/docker-compose-dev.yml creates a username `snitch_dev` with `snitch_dev` as a password instead of `postgres`

see docker-compose-dev.yml for reference: 
https://github.com/aviacommerce/avia/blob/d5f3befd6e9162f0f638d55ac9ab56c48b14a90f/config/docker/dev/docker-compose-dev.yml


<!--

Thank you for the PR! Contributors like you keep AviaCommerce awesome!

Please see the Contribution Guide for guidelines:

https://github.com/aviacommerce/avia/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->