### PR TITLE
Remove dupe docs nav Promotions link

### DIFF
--- a/content/docs/nav.yml
+++ b/content/docs/nav.yml
@@ -33,8 +33,6 @@
       title: Configurations
     - id: inventory
       title: Inventory
-    - id: promotions
-      title: Promotions
     # - id: reports
     #   title: Reports
     # - id: extentions


### PR DESCRIPTION
Fix for #33; removes duplicate mention of "Promotions" section from Getting Started docs nav.